### PR TITLE
Persist networks and restore them on startup.

### DIFF
--- a/daemon/net_plugin.go
+++ b/daemon/net_plugin.go
@@ -12,7 +12,7 @@ type netDriver struct {
 	plugin *plugins.Plugin
 }
 
-func (driver *netDriver) Create(network *Network) error {
+func (driver *netDriver) Setup(network *Network) error {
 	reader, err := driver.plugin.Call("POST", "", network)
 	if err != nil {
 		logrus.Warningf("Driver returned err:", err)

--- a/daemon/network/README.md
+++ b/daemon/network/README.md
@@ -8,9 +8,9 @@ Next steps are:
 - <s>docker run support</s>
 - <s>find appropriate hook for unplug</s>
 - <s>move code out of subdir to avoid circular imports</s>
-- make a plausible default/simple bridge driver
-- persistence and tear down / setup (in network/collection.go)
-- transport to external plugins (lukestensions?)
+- <s>make a plausible default/simple bridge driver</s>
+- <s>persistence and tear down / setup</s>
+- <s>transport to external plugins (lukestensions?)</s>
 - implement weave plugin.
 - make plug work for running containers
 


### PR DESCRIPTION
This changes driver.Create to Setup to reflect that it may be called when the network already exists (such as after a daemon crash).
